### PR TITLE
docs: adiciona README.md com tabela de alunos e instruções

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Makers Foundation 26.2 — Entregas dos Alunos
+
+Repositório para centralizar as entregas semanais dos alunos do programa **Makers Foundation 26.2** do [AI Lab — UnB](https://github.com/AI-Lab-UnB).
+
+## 📋 Estrutura do Repositório
+
+Cada aluno possui uma pasta própria com suas entregas organizadas por semana.
+
+| # | Pasta | Aluno |
+|---|-------|-------|
+| 1 | `Ana_Clara_Teixeira_251005883` | Ana Clara Teixeira |
+| 2 | `Arthur_Feitosa_232000721` | Arthur Feitosa Gonçalves Lima |
+| 3 | `Corina_Xavier_251007233` | Corina Xavier Carneiro |
+| 4 | `Felipe_Moreira_251008544` | Felipe Moreira da Silva Vieira |
+| 5 | `Gabriel-Escramin-251039569` | Gabriel Escramin Lourenço |
+| 6 | `Giovanni_Dornelas` | Giovanni Dornelas Ferreira |
+| 7 | `GustavoRocha_251021321` | Gustavo da Rocha Machado |
+| 8 | `JOAO_VICTOR_PEREIRA_SANTOS` | João Victor Pereira Santos |
+| 9 | `Joao_Pedro_Pellegrini` | João Pedro Pellegrini de Almeida |
+| 10 | `joao_paulo_nunes-232003652` | João Paulo Nunes |
+| 11 | `kauan_251035363` | Kauan Tarchetti Peixoto |
+| 12 | `Leticia_Lafeta_252014377` | Letícia Lafeta Naves |
+| 13 | `LeticiaPereira_25140256` | Letícia da Silva Pereira |
+| 14 | `Luis_Felipe_251012350` | Luís Felipe Albuquerque Fernandes |
+| 15 | `Luiz_Felipe_Mendes251012322` | Luiz Felipe Mendes |
+| 16 | `marcelo_252004147` | Marcelo Vitor Machado da Silva Filho |
+| 17 | `Maria_Julia_Sena_252004156` | Maria Júlia Sena |
+| 18 | `Maria-Luisa-Lima` | Maria Luísa Oliveira Lima |
+| 19 | `matheus-ribeiro-szervinsk` | Matheus Ribeiro Szervinsk |
+| 20 | `PedroMelo_251027432` | Pedro Oliveira Melo |
+| 21 | `Thomas_Augusto_251016027` | Thomas Augusto Amorim de Araújo |
+
+## 🚀 Fluxo de Trabalho
+
+1. **Crie sua branch** a partir da `main` com seu nome completo
+2. **Organize suas entregas** dentro da sua pasta pessoal, separando por semana
+3. **Faça commits** das suas atividades
+4. **Abra um Pull Request** para a `main` quando estiver pronto
+
+## 📁 Estrutura Sugerida por Aluno
+
+```
+Nome_Aluno_Matricula/
+├── Semana_01/
+│   └── Atividade1.md
+├── Semana_02/
+│   ├── Atividade1.pdf
+│   └── Atividade2.pdf
+└── ...
+```


### PR DESCRIPTION
Adiciona um `README.md` na raiz do repositório com:

- Descrição do projeto Makers Foundation 26.2
- Tabela com todos os 21 alunos que já tiveram PRs aceitos e suas respectivas pastas
- Instruções do fluxo de trabalho (branch → commits → PR)
- Estrutura sugerida de organização por semana

> **Nota:** O README.md original da main havia sido acidentalmente movido para dentro da pasta `GustavoRocha_251021321` durante o PR #28.